### PR TITLE
Remove comma from maintainer name for Debian compatibility

### DIFF
--- a/iceoryx_binding_c/package.xml
+++ b/iceoryx_binding_c/package.xml
@@ -4,7 +4,7 @@
     <name>iceoryx_binding_c</name>
     <version>2.0.5</version>
     <description>Eclipse iceoryx inter-process-communication (IPC) middleware C-Language Binding</description>
-    <maintainer email="iceoryx-oss-support@apex.ai">Eclipse Foundation, Inc.</maintainer>
+    <maintainer email="iceoryx-oss-support@apex.ai">Eclipse Foundation Inc.</maintainer>
     <license>Apache 2.0</license>
     <url type="website">https://iceoryx.io</url>
     <url type="bugtracker">https://github.com/eclipse-iceoryx/iceoryx/issues</url>

--- a/iceoryx_hoofs/package.xml
+++ b/iceoryx_hoofs/package.xml
@@ -4,7 +4,7 @@
     <name>iceoryx_hoofs</name>
     <version>2.0.5</version>
     <description>Eclipse iceoryx inter-process-communication (IPC) middleware basic building blocks</description>
-    <maintainer email="iceoryx-oss-support@apex.ai">Eclipse Foundation, Inc.</maintainer>
+    <maintainer email="iceoryx-oss-support@apex.ai">Eclipse Foundation Inc.</maintainer>
     <license>Apache 2.0</license>
     <url type="website">https://iceoryx.io</url>
     <url type="bugtracker">https://github.com/eclipse-iceoryx/iceoryx/issues</url>

--- a/iceoryx_integrationtest/package.xml
+++ b/iceoryx_integrationtest/package.xml
@@ -4,7 +4,7 @@
   <name>iceoryx_integrationtest</name>
   <version>2.0.5</version>
   <description>iceoryx Software Integrationtest</description>
-    <maintainer email="iceoryx-oss-support@apex.ai">Eclipse Foundation, Inc.</maintainer>
+    <maintainer email="iceoryx-oss-support@apex.ai">Eclipse Foundation Inc.</maintainer>
     <license>Apache 2.0</license>
     <url type="website">https://iceoryx.io</url>
     <url type="bugtracker">https://github.com/eclipse-iceoryx/iceoryx/issues</url>

--- a/iceoryx_posh/package.xml
+++ b/iceoryx_posh/package.xml
@@ -4,7 +4,7 @@
     <name>iceoryx_posh</name>
     <version>2.0.5</version>
     <description>Eclipse iceoryx inter-process-communication (IPC) middleware Posix Shared Memory Library and middleware daemon (RouDi)</description>
-    <maintainer email="iceoryx-oss-support@apex.ai">Eclipse Foundation, Inc.</maintainer>
+    <maintainer email="iceoryx-oss-support@apex.ai">Eclipse Foundation Inc.</maintainer>
     <license>Apache 2.0</license>
     <url type="website">https://iceoryx.io</url>
     <url type="bugtracker">https://github.com/eclipse-iceoryx/iceoryx/issues</url>

--- a/tools/introspection/package.xml
+++ b/tools/introspection/package.xml
@@ -4,7 +4,7 @@
     <name>iceoryx_introspection</name>
     <version>2.0.5</version>
     <description>Eclipse iceoryx inter-process-communication (IPC) middleware introspection client</description>
-    <maintainer email="iceoryx-oss-support@apex.ai">Eclipse Foundation, Inc.</maintainer>
+    <maintainer email="iceoryx-oss-support@apex.ai">Eclipse Foundation Inc.</maintainer>
     <license>Apache 2.0</license>
     <url type="website">https://iceoryx.io</url>
     <url type="bugtracker">https://github.com/eclipse-iceoryx/iceoryx/issues</url>


### PR DESCRIPTION
The comma in 'Eclipse Foundation, Inc.' causes malformed-contact errors in Debian packaging tools (Lintian). This PR removes the comma to allow successful builds.