### PR TITLE
Fix Maintainer name in posh debian/control (resolute)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: ros-rolling-iceoryx-posh
 Section: misc
 Priority: optional
-Maintainer: Eclipse Foundation, Inc. <iceoryx-oss-support@apex.ai>
+Maintainer: Eclipse Foundation Inc. <iceoryx-oss-support@apex.ai>
 Build-Depends: debhelper (>= 9.0.0), cmake, git, ros-rolling-iceoryx-hoofs, ros-rolling-ros-workspace
 Homepage: https://iceoryx.io
 Standards-Version: 3.9.2


### PR DESCRIPTION
Fixes malformed-contact error by removing the comma from the Maintainer name.